### PR TITLE
fix(auth): fail fast on missing Keycloak env vars instead of defaulti…

### DIFF
--- a/apps/obo-blocks/src/components/esp32-output-panel.tsx
+++ b/apps/obo-blocks/src/components/esp32-output-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DeleteOutlined, StopOutlined, LinkOutlined, DisconnectOutlined } from "@ant-design/icons";
-import { useESP32Uploader, ESP32REPL, type SerialPort } from "@nexus-tools/esp32-uploader";
+import { useESP32Uploader, ESP32REPL, ESP32Flasher, type SerialPort } from "@nexus-tools/esp32-uploader";
 import { Button as UIButton } from "@nexus-tools/ui";
 import { Tabs, Space, Button } from "antd";
 import { useState, useMemo, useCallback, useRef, useEffect, forwardRef, useImperativeHandle } from "react";

--- a/apps/obo-blocks/src/components/navbar.tsx
+++ b/apps/obo-blocks/src/components/navbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { signOut, useSession } from "next-auth/react";
 import { getPublicKeycloakConfig } from "@nexus-tools/auth";
+import { signOut, useSession } from "next-auth/react";
 
 const { keycloakUrl, realm, clientId } = getPublicKeycloakConfig();
 

--- a/apps/obo-blocks/src/components/navbar.tsx
+++ b/apps/obo-blocks/src/components/navbar.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { signOut, useSession } from "next-auth/react";
+import { getPublicKeycloakConfig } from "@nexus-tools/auth";
+
+const { keycloakUrl, realm, clientId } = getPublicKeycloakConfig();
 
 export function Navbar() {
   const { data: session } = useSession();
-  const keycloakUrl = process.env.NEXT_PUBLIC_KEYCLOAK_URL || "https://auth.roboticgen.co";
-  const realm = process.env.NEXT_PUBLIC_KEYCLOAK_REALM || "roboticgen";
-  const clientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID || "obo-nexus";
 
   const handleLogout = async () => {
     await signOut({ redirect: false });

--- a/apps/obo-code/src/components/esp32-output-panel.tsx
+++ b/apps/obo-code/src/components/esp32-output-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DeleteOutlined, StopOutlined, LinkOutlined, DisconnectOutlined } from "@ant-design/icons";
-import { useESP32Uploader, ESP32REPL, type SerialPort } from "@nexus-tools/esp32-uploader";
+import { useESP32Uploader, ESP32REPL, ESP32Flasher, type SerialPort } from "@nexus-tools/esp32-uploader";
 import { Button as UIButton } from "@nexus-tools/ui";
 import { Tabs, Space, Button } from "antd";
 import { useState, useMemo, useCallback, useRef, useEffect, forwardRef, useImperativeHandle } from "react";
@@ -90,10 +90,11 @@ export const ESP32OutputPanel = forwardRef<ESP32OutputPanelHandle, ESP32OutputPa
     serialPort,
     isFlashing,
     espSupported,
+    connectionError,
     connectToDevice,
     resetConnection,
     saveFileToDevice,
-  } = useESP32Uploader({ 
+  } = useESP32Uploader({
     code, 
     onStatusUpdate, 
     onError,
@@ -173,7 +174,7 @@ export const ESP32OutputPanel = forwardRef<ESP32OutputPanelHandle, ESP32OutputPa
             }}>
               <strong>Web Serial API not available</strong>
               <br />
-              This browser doesn't support Web Serial API. Please use Chrome, Edge, or Opera on HTTPS or localhost.
+              This browser doesn&apos;t support Web Serial API. Please use Chrome, Edge, or Opera on HTTPS or localhost.
             </div>
           )}
           {espSupported !== false && (

--- a/apps/obo-code/src/components/navbar.tsx
+++ b/apps/obo-code/src/components/navbar.tsx
@@ -3,12 +3,12 @@
 import Image from "next/image";
 import Link from "next/link";
 import { signOut, useSession } from "next-auth/react";
+import { getPublicKeycloakConfig } from "@nexus-tools/auth";
+
+const { keycloakUrl, realm, clientId } = getPublicKeycloakConfig();
 
 export function Navbar() {
   const { data: session } = useSession();
-  const keycloakUrl = process.env.NEXT_PUBLIC_KEYCLOAK_URL || "https://auth.roboticgen.co";
-  const realm = process.env.NEXT_PUBLIC_KEYCLOAK_REALM || "roboticgen";
-  const clientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID || "obo-nexus";
 
   const handleLogout = async () => {
     await signOut({ redirect: false });

--- a/apps/obo-code/src/components/navbar.tsx
+++ b/apps/obo-code/src/components/navbar.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { getPublicKeycloakConfig } from "@nexus-tools/auth";
 import Image from "next/image";
 import Link from "next/link";
 import { signOut, useSession } from "next-auth/react";
-import { getPublicKeycloakConfig } from "@nexus-tools/auth";
 
 const { keycloakUrl, realm, clientId } = getPublicKeycloakConfig();
 

--- a/apps/obo-playground/src/components/logout-button.tsx
+++ b/apps/obo-playground/src/components/logout-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { signOut, useSession } from "next-auth/react";
 import { getPublicKeycloakConfig } from "@nexus-tools/auth";
+import { signOut, useSession } from "next-auth/react";
 
 const { keycloakUrl, realm, clientId } = getPublicKeycloakConfig();
 

--- a/apps/obo-playground/src/components/logout-button.tsx
+++ b/apps/obo-playground/src/components/logout-button.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { signOut, useSession } from "next-auth/react";
+import { getPublicKeycloakConfig } from "@nexus-tools/auth";
+
+const { keycloakUrl, realm, clientId } = getPublicKeycloakConfig();
 
 export function LogoutButton() {
   const { data: session } = useSession();
-  const keycloakUrl = process.env.NEXT_PUBLIC_KEYCLOAK_URL || "https://auth.roboticgen.co";
-  const realm = process.env.NEXT_PUBLIC_KEYCLOAK_REALM || "roboticgen";
-  const clientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID || "obo-nexus";
 
   const handleLogout = async () => {
     await signOut({ redirect: false });

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -23,11 +23,15 @@ export interface PublicKeycloakConfig {
  * falling back to production.
  */
 export function getPublicKeycloakConfig(): PublicKeycloakConfig {
-  return {
-    keycloakUrl: required("NEXT_PUBLIC_KEYCLOAK_URL"),
-    realm: required("NEXT_PUBLIC_KEYCLOAK_REALM"),
-    clientId: required("NEXT_PUBLIC_KEYCLOAK_CLIENT_ID"),
-  };
+  const keycloakUrl = process.env.NEXT_PUBLIC_KEYCLOAK_URL;
+  const realm = process.env.NEXT_PUBLIC_KEYCLOAK_REALM;
+  const clientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID;
+
+  if (!keycloakUrl) throw new Error("NEXT_PUBLIC_KEYCLOAK_URL env var is required");
+  if (!realm) throw new Error("NEXT_PUBLIC_KEYCLOAK_REALM env var is required");
+  if (!clientId) throw new Error("NEXT_PUBLIC_KEYCLOAK_CLIENT_ID env var is required");
+
+  return { keycloakUrl, realm, clientId };
 }
 
 /**

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -2,18 +2,43 @@ import type { NextAuthOptions } from "next-auth";
 import KeycloakProvider from "next-auth/providers/keycloak";
 import type { NextAuthSession } from "./types";
 
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} env var is required`);
+  }
+  return value;
+}
+
+export interface PublicKeycloakConfig {
+  keycloakUrl: string;
+  realm: string;
+  clientId: string;
+}
+
+/**
+ * Keycloak connection details needed by client components (e.g. RP-initiated
+ * logout). These are NEXT_PUBLIC_* vars inlined at build time, so a missing
+ * value must fail as soon as this module is evaluated rather than silently
+ * falling back to production.
+ */
+export function getPublicKeycloakConfig(): PublicKeycloakConfig {
+  return {
+    keycloakUrl: required("NEXT_PUBLIC_KEYCLOAK_URL"),
+    realm: required("NEXT_PUBLIC_KEYCLOAK_REALM"),
+    clientId: required("NEXT_PUBLIC_KEYCLOAK_CLIENT_ID"),
+  };
+}
+
 /**
  * Get NextAuth configuration for Keycloak OAuth provider
- * Environment variables should be set: KEYCLOAK_URL, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET, KEYCLOAK_REALM, NEXTAUTH_URL
+ * Environment variables must be set: KEYCLOAK_URL, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET, KEYCLOAK_REALM, NEXTAUTH_URL
  */
 export function getAuthConfig(): NextAuthOptions {
-  const keycloakUrl = process.env.KEYCLOAK_URL || "https://auth.roboticgen.co";
-  const realm = process.env.KEYCLOAK_REALM || "roboticgen";
-  const clientId = process.env.KEYCLOAK_CLIENT_ID || "obo-nexus";
-  const clientSecret = process.env.KEYCLOAK_CLIENT_SECRET;
-  if (!clientSecret) {
-    throw new Error("KEYCLOAK_CLIENT_SECRET env var is required");
-  }
+  const keycloakUrl = required("KEYCLOAK_URL");
+  const realm = required("KEYCLOAK_REALM");
+  const clientId = required("KEYCLOAK_CLIENT_ID");
+  const clientSecret = required("KEYCLOAK_CLIENT_SECRET");
   const nextAuthUrl = process.env.NEXTAUTH_URL || "http://localhost:3001";
 
   // Log configuration for debugging (development only)

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,2 +1,3 @@
-export { getAuthConfig } from "./config";
+export { getAuthConfig, getPublicKeycloakConfig } from "./config";
+export type { PublicKeycloakConfig } from "./config";
 export type { KeycloakToken, NextAuthSession, AuthConfig } from "./types";


### PR DESCRIPTION
…ng to prod

Previously the Keycloak URL, realm, and client ID silently fell back to production values when their env vars were unset, so a misconfigured staging/preview deploy would authenticate against prod without warning. Only KEYCLOAK_CLIENT_SECRET failed loudly. Treat all Keycloak vars the same way: throw if missing.

Adds a shared getPublicKeycloakConfig() in @nexus-tools/auth for the NEXT_PUBLIC_* variants used by the three logout handlers, replacing the duplicated fallback logic and failing at module load instead of on click.