### PR TITLE
docs: add missing Keycloak/NextAuth env vars to .env.example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ Each app has an `.env.example` file. Copy it to `.env.local` and fill in the val
 cp apps/obo-code/.env.example apps/obo-code/.env.local
 ```
 
+Each app also needs Keycloak/NextAuth variables (`KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, and the `NEXT_PUBLIC_KEYCLOAK_*` equivalents) — these are included in each `.env.example`. Two things to know:
+
+- `NEXTAUTH_URL` differs per app since each runs on its own port (obo-code: 3001, obo-blocks: 3002, obo-playground: 3003). Keycloak must have all three `/api/auth/callback/keycloak` URLs registered as valid redirect URIs, and the three `/login` URLs as valid post-logout redirect URIs.
+- The `NEXT_PUBLIC_*` variables are inlined into the client bundle at build time, so they must be set before running `next build`, not just at runtime.
+- `NEXTAUTH_SECRET` is required by NextAuth in production; leaving it unset makes `next build` fail with a `NO_SECRET` error. Generate one with `openssl rand -base64 32`.
+
 ## 📄 License
 
 MIT

--- a/apps/obo-blocks/.env.example
+++ b/apps/obo-blocks/.env.example
@@ -7,3 +7,16 @@ NEXT_PUBLIC_APP_URL=http://localhost:3002
 
 # API
 NEXT_PUBLIC_API_URL=http://localhost:4000/api
+
+# Keycloak / NextAuth (server-side)
+KEYCLOAK_URL=https://auth.roboticgen.co
+KEYCLOAK_REALM=roboticgen
+KEYCLOAK_CLIENT_ID=obo-nexus
+KEYCLOAK_CLIENT_SECRET=
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=http://localhost:3002
+
+# Keycloak (client-side, inlined at build time)
+NEXT_PUBLIC_KEYCLOAK_URL=https://auth.roboticgen.co
+NEXT_PUBLIC_KEYCLOAK_REALM=roboticgen
+NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=obo-nexus

--- a/apps/obo-code/.env.example
+++ b/apps/obo-code/.env.example
@@ -7,3 +7,16 @@ NEXT_PUBLIC_APP_URL=http://localhost:3001
 
 # API
 NEXT_PUBLIC_API_URL=http://localhost:4000/api
+
+# Keycloak / NextAuth (server-side)
+KEYCLOAK_URL=https://auth.roboticgen.co
+KEYCLOAK_REALM=roboticgen
+KEYCLOAK_CLIENT_ID=obo-nexus
+KEYCLOAK_CLIENT_SECRET=
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=http://localhost:3001
+
+# Keycloak (client-side, inlined at build time)
+NEXT_PUBLIC_KEYCLOAK_URL=https://auth.roboticgen.co
+NEXT_PUBLIC_KEYCLOAK_REALM=roboticgen
+NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=obo-nexus

--- a/apps/obo-playground/.env.example
+++ b/apps/obo-playground/.env.example
@@ -7,3 +7,16 @@ NEXT_PUBLIC_APP_URL=http://localhost:3003
 
 # API
 NEXT_PUBLIC_API_URL=http://localhost:4000/api
+
+# Keycloak / NextAuth (server-side)
+KEYCLOAK_URL=https://auth.roboticgen.co
+KEYCLOAK_REALM=roboticgen
+KEYCLOAK_CLIENT_ID=obo-nexus
+KEYCLOAK_CLIENT_SECRET=
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=http://localhost:3003
+
+# Keycloak (client-side, inlined at build time)
+NEXT_PUBLIC_KEYCLOAK_URL=https://auth.roboticgen.co
+NEXT_PUBLIC_KEYCLOAK_REALM=roboticgen
+NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=obo-nexus


### PR DESCRIPTION
New contributors following the README couldn't get auth working since KEYCLOAK_*, NEXTAUTH_*, and NEXT_PUBLIC_KEYCLOAK_* vars (all declared in turbo.json's globalEnv) were absent from every app's .env.example. NEXTAUTH_SECRET in particular fails `next build` in production with an unhelpful NO_SECRET error when unset