### PR TITLE
fix(auth): reject errored refresh tokens in middleware

### DIFF
--- a/apps/obo-blocks/src/middleware.ts
+++ b/apps/obo-blocks/src/middleware.ts
@@ -17,8 +17,8 @@ export default withAuth(
           return true;
         }
 
-        // For all other routes, require authentication
-        return !!token;
+        // For all other routes, require authentication with a valid (non-errored) token
+        return !!token && !token.error;
       },
     },
     pages: {

--- a/apps/obo-code/src/components/esp32-output-panel.tsx
+++ b/apps/obo-code/src/components/esp32-output-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DeleteOutlined, StopOutlined, LinkOutlined, DisconnectOutlined } from "@ant-design/icons";
-import { useESP32Uploader, ESP32REPL, type SerialPort } from "@nexus-tools/esp32-uploader";
+import { useESP32Uploader, ESP32REPL, ESP32Flasher, type SerialPort } from "@nexus-tools/esp32-uploader";
 import { Button as UIButton } from "@nexus-tools/ui";
 import { Tabs, Space, Button } from "antd";
 import { useState, useMemo, useCallback, useRef, useEffect, forwardRef, useImperativeHandle } from "react";
@@ -93,7 +93,8 @@ export const ESP32OutputPanel = forwardRef<ESP32OutputPanelHandle, ESP32OutputPa
     connectToDevice,
     resetConnection,
     saveFileToDevice,
-  } = useESP32Uploader({ 
+    connectionError,
+  } = useESP32Uploader({
     code, 
     onStatusUpdate, 
     onError,

--- a/apps/obo-code/src/middleware.ts
+++ b/apps/obo-code/src/middleware.ts
@@ -17,8 +17,8 @@ export default withAuth(
           return true;
         }
 
-        // For all other routes, require authentication
-        return !!token;
+        // For all other routes, require authentication with a valid (non-errored) token
+        return !!token && !token.error;
       },
     },
     pages: {

--- a/apps/obo-playground/src/middleware.ts
+++ b/apps/obo-playground/src/middleware.ts
@@ -17,8 +17,8 @@ export default withAuth(
           return true;
         }
 
-        // For all other routes, require authentication
-        return !!token;
+        // For all other routes, require authentication with a valid (non-errored) token
+        return !!token && !token.error;
       },
     },
     pages: {


### PR DESCRIPTION
The jwt callback signals a failed Keycloak token refresh by returning { ...token, error: "RefreshAccessTokenError" } rather than dropping the token, but the middleware's authorized check only tested !!token, so a truthy-but-errored token still passed the gate. Users landed in the app with a dead session that only failed later on the first API call. Now checks !!token && !token.error in all three app middlewares.

Also fixes a ReferenceError in obo-code's ESP32OutputPanel: ESP32Flasher and connectionError were exported/returned by the esp32-uploader package but never imported/destructured in the component.